### PR TITLE
Fix killing emacsclient session when created on a directory

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -486,8 +486,10 @@ ARGS is a list of keyword arguments for `dirvish' struct."
   "Kill the dirvish instance DV."
   (let ((index (cdr (dv-index dv))))
     (if (not (car (dv-layout dv)))
-        (cl-loop for (_d . b) in (dv-roots dv) when
-                 (not (get-buffer-window b)) do (kill-buffer b)
+        (cl-loop for (_d . b) in (dv-roots dv)
+                 when (and (not (get-buffer-window b))
+                           (not (with-current-buffer b server-buffer-clients)))
+                 do (kill-buffer b)
                  finally (setf (dv-index dv) (car (dv-roots dv))))
       (when dirvish-use-header-line
         (with-current-buffer index


### PR DESCRIPTION
When an emacsclient frame is created by visitng directory A, and then the user goes into subdirectory B and opens a file using dirvish-find-entry-a, the buffer for A no longer has a window and gets killed by dirvish-kill. Since this was the original buffer the client was opened with, this causes the client frame to be killed along with it, resulting in the frame going away instead of showing the file. This has been reported earlier in [0] and [1].

This can be reproduced by following the below steps mentioned in [0]:

    mkdir tmp && cd tmp
    mkdir dir
    touch dir/foo

    emacsclient -nw .
    # RET -- open `dir`
    # RET -- try to open `foo`

This will cause the frame to close instead of opening foo.

For buffers tied with a client, the variable server-buffer-clients is non-nil. Use that to detect such buffers and avoid killing them. Those buffers will be killed by the user when they wish to close their session.

[0] https://github.com/doomemacs/doomemacs/issues/8253
[1] https://github.com/alexluigit/dirvish/issues/232

----
Notes:
- I am not so well versed with emacs and its client-server stuff, so I am not 100% sure if checking `server-buffer-clients` is the right thing to do, but in my testing it works perfectly.
- Upstream pull request: https://github.com/alexluigit/dirvish/pull/293